### PR TITLE
Use whatever version of php is set on the path.

### DIFF
--- a/vanilla
+++ b/vanilla
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
  * @copyright 2009-2017 Vanilla Forums Inc.


### PR DESCRIPTION
`/usr/bin/php` is not necessarily going to be on the path or point to the correct version of php that someone wants to use. We should load `/usr/bin/env` then call out to whichever `php` they set on their path.