### PR TITLE
Resolve php path using env instead of defaulting on /usr/bin/php

### DIFF
--- a/vanilla
+++ b/vanilla
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 /**
  * @copyright 2009-2017 Vanilla Forums Inc.


### PR DESCRIPTION
Before this update `php vanilla` could be called on a different version than `./vanilla` which would be 5.6.30 on Max OSX (this is the default shipped version).

The script now uses /usr/bin/env to know the php binary location.