### PR TITLE
Remove specific command references from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ See the [wiki](https://github.com/vanilla/vanilla-cli/wiki) for documentation ab
 ## Prerequisites
 The CLI requires PHP `5.6.0` or greater installed to run. 
 
-Additionally the command `build` requires a minimum Node.js version of `8.0.0` and the package manager `yarn` to be installed. Installation instructions [below](#for-os-x).
+Some commands, currently `build`, requires a minimum Node.js version of `8.0.0` and the package manager `yarn` to be installed. Installation instructions are located [in the wik](https://github.com/vanilla/vanilla-cli/wiki/Node.js-Processes).
 
 ## Table of Contents
 
 * [Installation](#installation)
 * [Usage](#usage)
-* [Build Tool](#build-tool)
 * [Debugging](#debugging)
 * [Documentation](#documentation)
 * [License](#license)
@@ -40,23 +39,6 @@ ln -s /usr/local/bin
 ```
 ```bash
 ln -s ~/bin
-```
-
-If you would like to use the frontend build tools as well, you will need to have `node` and `yarn` installed.
-
-#### For OS X
-```bash
-brew install node
-brew install yarn
-```
-
-#### For Debian/Ubuntu Linux
-```bash
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
-curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-
-sudo apt-get update && sudo apt-get install nodejs yarn
 ```
 
 ## Usage
@@ -80,15 +62,6 @@ try {
 }
 ```
 
-### Build Tool
-Both the core of Vanilla and its many addons often have their own tools to build their frontend dependencies. Normally these tools bundle, concatenate, and/or minify the javascript and styles, compress images and other assets, and may include a CSS authoring tool such as [Sass](http://sass-lang.com/) or [Less](http://lesscss.org/). Many of these build toolchains accomplish the same objective but in different ways.
-
-The build tool aims to provide a consistant experience to building a frontend assets for vanilla (js/css/images). By default it will check your project for an existing build process and attempt to hook into that, but it provides its own mature, well tested build processes as well.
-
-You can choose which build process to use by defining a `buildProcessVersion` in your project's [addon.json](http://docs.vanillaforums.com/developer) file and settings it to a valid build process version. Currently valid versions are `1.0` and `legacy`
-
-For information on the build process and its configuration, check the [wiki](https://github.com/vanilla/vanilla-cli/wiki/Build-Tools)
-
 ## Debugging
 During local development you main want to run a debugger. This is supported for both php process and JS process.
 
@@ -110,9 +83,6 @@ Just export `XDEBUG_CONFIG` from your shell, set up your IDE to listen for XDebu
 export XDEBUG_CONFIG="idekey=PHPSTORM"
 vanilla some-command --some-argument
 ```
-
-### Node.js
-The build processes of this tool use [Node.js](https://nodejs.org/en/). Debugging of the node processes are not officially supported at this time. PR's welcome.
 
 ## Documentation
 Documentation can be found at this repo's [wiki](https://github.com/vanilla/vanilla-cli/wiki).


### PR DESCRIPTION
I've slimmed down the readme and removed references to specific command generally. I've moved the node.js installation instructions to the wiki.