### PR TITLE
Fix AddonJsonCmd unset variable order

### DIFF
--- a/src/Vanilla/Cli/Command/AddonCacheCmd.php
+++ b/src/Vanilla/Cli/Command/AddonCacheCmd.php
@@ -24,16 +24,14 @@ class AddonCacheCmd extends AddonCommandBase {
      */
     public function __construct(Cli $cli) {
         parent::__construct($cli);
-        $cli
-            ->description('Generate addons\'s cache files.')
-            ->opt('regenerate:r', 'Regenerate the cache files.')
-        ;
+        $cli->description('Generate addons\'s cache files.')
+            ->opt('regenerate:r', 'Regenerate the cache files.');
     }
 
     /**
      * @inheritdoc
      */
-    public function doRun(Args $args, AddonManager $addonManager) {
+    protected function doRun(Args $args, AddonManager $addonManager) {
         if ($args->getOpt('regenerate', false) !== false) {
             $addonManager->clearCache();
         }

--- a/src/Vanilla/Cli/Command/AddonDoctorCmd.php
+++ b/src/Vanilla/Cli/Command/AddonDoctorCmd.php
@@ -40,7 +40,7 @@ class AddonDoctorCmd extends AddonCommandBase {
     /**
      * @inheritdoc
      */
-    public function doRun(Args $args, AddonManager $addonManager) {
+    protected function doRun(Args $args, AddonManager $addonManager) {
         $getRelativePath = function($from, $path) {
             $path = explode(DIRECTORY_SEPARATOR, $path);
             $from = explode(DIRECTORY_SEPARATOR, $from);

--- a/src/Vanilla/Cli/Command/AddonJsonCmd.php
+++ b/src/Vanilla/Cli/Command/AddonJsonCmd.php
@@ -40,7 +40,7 @@ class AddonJsonCmd extends AddonCommandBase {
     /**
      * @inheritdoc
      */
-    public function doRun(Args $args, AddonManager $addonManager) {
+    protected function doRun(Args $args, AddonManager $addonManager) {
         $addonsOutput = '';
         $warningsOutput = '';
         foreach (array_keys($addonManager->getScanDirs()) as $addonType) {

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -124,8 +124,6 @@ class BuildCmd extends NodeCommandBase {
 
         $packageJson = json_decode(file_get_contents($packageJsonPath), true);
         $shouldUpdate = true;
-        $vanillaBuild = false;
-        $outputMessage = '';
 
         if (file_exists($vanillaBuildPath)) {
             $vanillaBuild = json_decode(file_get_contents($vanillaBuildPath), true);

--- a/src/Vanilla/Cli/Command/Command.php
+++ b/src/Vanilla/Cli/Command/Command.php
@@ -46,5 +46,5 @@ abstract class Command {
      * @param Args $args
      * @return mixed
      */
-    abstract function run(Args $args);
+    public abstract function run(Args $args);
 }


### PR DESCRIPTION
Fix a bug with AddonJsonCmd unset order.
Fixes method visibility and remove unused variables.