### PR TITLE
Fix importing of css files in custom importer

### DIFF
--- a/src/Vanilla/FrontendTools/versions/1.0/build.stylesheets.js
+++ b/src/Vanilla/FrontendTools/versions/1.0/build.stylesheets.js
@@ -62,18 +62,25 @@ function buildStylesheets(addonDirectory, options) {
         ));
 
         const jsonDirectory = path.resolve(baseDirectory, 'package.json');
+        let fileName = "";
         if (fs.existsSync(jsonDirectory)) {
             const json = require(jsonDirectory);
             if (json.style) {
-                return done({file: path.resolve(baseDirectory, json.style)});
+                fileName = path.resolve(baseDirectory, json.style);
             } else if (json.main && json.main.match(/.scss$/)) {
-                return done({file: path.resolve(baseDirectory, json.main)});
+                fileName = path.resolve(baseDirectory, json.main);
             } else {
                 throw new Error(`No SCSS file found for module ${baseDirectory}}`);
             }
         } else {
             throw new Error(`No package.json found for ${jsonDirectory}}`);
         }
+
+        if (fileName.endsWith('.css')) {
+            fileName = fileName.slice(0, -4);
+        }
+
+        return done({file: fileName});
     }
     const destination = path.resolve(addonDirectory, 'design');
 


### PR DESCRIPTION
Fixes #25 

Allows the custom importer to do a sass style import of css files it finds in a `package.json` by removing the .css at the end if it exists.

Given the following file:

**a.css**
```scss
.Test {
   color: red;
}
```

The following files will produce the following output from sass
**Entry file `b.scss`**
```scss
    @import "/path/to/a.css";
```

**Output file `b.css`**
```scss
    @import url("/path/to/a.css");
```

**Entry file `c.scss`**
```scss
    @import "/path/to/a";
```

**Output file `c.css`**
```scss
.Test {
   color: red;
}
```

Because the transformation in file C is the desired behaviour, the importer now sees a custom module (.css) and removes the explicit file extension `.css` if it exists in order to inline the file properly.