### PR TITLE
Allow tool to be globally installed by composer

### DIFF
--- a/bin/vanilla
+++ b/bin/vanilla
@@ -1,11 +1,42 @@
 #!/usr/bin/env php
 <?php
+
 /**
  * @copyright 2009-2017 Vanilla Forums Inc.
  * @license MIT
  */
 
-require(__DIR__.'/../vendor/autoload.php');
+/**
+ * Loading autoload files the normal way only works for tools installed locally, not globally
+ * Inspired by PHPUnit https://github.com/sebastianbergmann/phpunit/blob/master/phpunit
+ */
+$possibleAutoloadFiles = [
+    __DIR__.'/../../../autoload.php',
+    __DIR__.'/../../autoload.php',
+    __DIR__.'/../vendor/autoload.php',
+];
+
+foreach ($possibleAutoloadFiles as $file) {
+    if (file_exists($file)) {
+        define('VANILLA_CLI_AUTOLOADER_PATH', $file);
+        break;
+    }
+}
+
+unset($file);
+
+if (!defined('VANILLA_CLI_AUTOLOADER_PATH')) {
+    fwrite(
+        STDERR,
+        'You need to set up the project dependencies using Composer:'.PHP_EOL.PHP_EOL.
+        '    composer install'.PHP_EOL.PHP_EOL.
+        'You can learn all about Composer on https://getcomposer.org/.'.PHP_EOL
+    );
+    die(1);
+}
+
+require VANILLA_CLI_AUTOLOADER_PATH;
+
 $cli = new \Vanilla\Cli\Cli();
 try {
     $cli->run();

--- a/bin/vanilla
+++ b/bin/vanilla
@@ -1,6 +1,5 @@
 #!/usr/bin/env php
 <?php
-
 /**
  * @copyright 2009-2017 Vanilla Forums Inc.
  * @license MIT


### PR DESCRIPTION
This tool would fail when globally installed with composer as recommended in the README. The bin file would be located at `~/.composer/vendor/vanilla/vanilla-cli/bin/vanilla` and would try the path `__DIR__.'/../vendor/autoload.php'`. This works for project scoped composer tools, but when globally installed the autoload file will be located at `~/.composer/vendor/autoload.php`.

I looked at some other PHP projects and this seems to be how `PHPUnit` does it.