### PR TITLE
Fix build process bugs

### DIFF
--- a/src/Vanilla/FrontendTools/versions/1.0/build.stylesheets.js
+++ b/src/Vanilla/FrontendTools/versions/1.0/build.stylesheets.js
@@ -98,7 +98,13 @@ function buildStylesheets(addonDirectory, options) {
         //     })
         // )
         .pipe(sass({importer}))
-        .pipe(autoprefixer())
+        .pipe(autoprefixer({
+            browsers: [
+                "ie > 9",
+                "last 6 iOS versions",
+                "last 4 versions"
+            ]
+        }))
         .pipe(cssnano())
         .pipe(sourcemaps.write('.'))
         .on('error', swallowError)

--- a/src/Vanilla/FrontendTools/versions/1.0/gulpfile.js
+++ b/src/Vanilla/FrontendTools/versions/1.0/gulpfile.js
@@ -53,8 +53,8 @@ gulp.task("watch", ["build"], () => {
         }
     );
 
-    gulp.watch(path.resolve(addonpath, "**/*.scss"), ["build:styles"]);
-    gulp.watch(path.resolve(addonpath, "**/*.js"), ["build:js"]);
+    gulp.watch(path.resolve(addonpath, "src/**/*.scss"), ["build:styles"]);
+    gulp.watch(path.resolve(addonpath, "src/**/*.js"), ["build:js"]);
     gulp.watch(path.resolve(addonpath, "design/images/**/*"), ["build:assets"]);
 });
 

--- a/src/Vanilla/FrontendTools/versions/1.0/yarn.lock
+++ b/src/Vanilla/FrontendTools/versions/1.0/yarn.lock
@@ -1706,12 +1706,6 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-d@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
-  dependencies:
-    es5-ext "~0.10.2"
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -2138,7 +2132,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.10, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.8:
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.23"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
   dependencies:
@@ -2153,17 +2147,6 @@ es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     es5-ext "^0.10.14"
     es6-symbol "^3.1"
 
-es6-map@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.3.tgz#fe58c6654c6acd54e4397cdb72379d59b6ad5894"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.8"
-    es6-iterator "2"
-    es6-set "~0.1.3"
-    es6-symbol "~3.0.1"
-    event-emitter "~0.3.4"
-
 es6-map@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
@@ -2175,7 +2158,7 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.1"
     event-emitter "~0.3.5"
 
-es6-set@~0.1.3, es6-set@~0.1.5:
+es6-set@~0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
   dependencies:
@@ -2191,13 +2174,6 @@ es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbo
   dependencies:
     d "1"
     es5-ext "~0.10.14"
-
-es6-symbol@~3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.0.2.tgz#1e928878c6f5e63541625b4bb4df4af07d154219"
-  dependencies:
-    d "~0.1.1"
-    es5-ext "~0.10.10"
 
 es6-weak-map@^2.0.1:
   version "2.0.2"
@@ -2380,7 +2356,7 @@ etag@^1.7.0, etag@~1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
 
-event-emitter@~0.3.4, event-emitter@~0.3.5:
+event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   dependencies:
@@ -2930,7 +2906,7 @@ glob@^5.0.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -4913,10 +4889,6 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.0.1.tgz#99504456c3598b5cad4fc59c26e8a9bb107fe0bd"
-
 object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
@@ -5967,10 +5939,6 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-resolve-bower@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-bower/-/resolve-bower-0.0.1.tgz#0ce69ebb19604302b163abd9d8d8da154555d0f2"
-
 resolve-dir@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
@@ -5989,10 +5957,6 @@ resolve-from@^3.0.0:
 resolve-url@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
 resolve@^1.1.6, resolve@^1.1.7:
   version "1.3.3"
@@ -6077,16 +6041,6 @@ sass-graph@^2.1.1:
     lodash "^4.0.0"
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
-
-sass-module-importer@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/sass-module-importer/-/sass-module-importer-1.4.0.tgz#ed0400f9c1a40f017790a1772da0beb5432f9149"
-  dependencies:
-    es6-map "0.1.3"
-    glob "^7.1.1"
-    object-assign "4.0.1"
-    resolve "1.1.7"
-    resolve-bower "0.0.1"
 
 sax@~1.2.1:
   version "1.2.2"


### PR DESCRIPTION
Restricts watching of the source files to inside of the `src` folder. This is the only place they get searched for anyways, and expanding the watch process to any javascript files in particular can cause the watch process to run out of memory as it will try to watch an entire `node_modules` or `bower_components` folder. If someone changes a `node_module` they can restart their watch process.

Additionally in certain versions of node, autoprefixer was failing to pick up the browsers set in the package.json, so I've manually specified them. I'll investigate that further when we switch the tool from using the deprecated version of autoprefixer and use the autoprefixer PostCSS plugin instead.