### PR TITLE
Add Less stylesheet support 

### DIFF
--- a/src/BuildTools/versions/v1/package.json
+++ b/src/BuildTools/versions/v1/package.json
@@ -21,6 +21,7 @@
         "gulp-cssnano": "^2.1.2",
         "gulp-eslint": "^4.0.0",
         "gulp-imagemin": "^3.3.0",
+        "gulp-less": "^3.3.2",
         "gulp-livereload": "^3.8.1",
         "gulp-plumber": "^1.1.0",
         "gulp-rename": "^1.2.2",

--- a/src/BuildTools/versions/v1/vanilla-build-v1.js
+++ b/src/BuildTools/versions/v1/vanilla-build-v1.js
@@ -21,7 +21,8 @@ const passedOptions = JSON.parse(argv.options);
 
 const options = {
     isVerboseMode: passedOptions.verbose || false,
-    isWatchMode: passedOptions.watch || false
+    isWatchMode: passedOptions.watch || false,
+    cssTool: passedOptions.cssTool || 'scss',
 }
 
 gulp.task("build:js", () => {

--- a/src/BuildTools/versions/v1/yarn.lock
+++ b/src/BuildTools/versions/v1/yarn.lock
@@ -44,6 +44,25 @@ accepts@~1.3.3:
     mime-types "~2.1.16"
     negotiator "0.6.1"
 
+accord@^0.27.3:
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/accord/-/accord-0.27.3.tgz#7fb9129709285caea84eb372c4e882031b7138e8"
+  dependencies:
+    convert-source-map "^1.5.0"
+    glob "^7.0.5"
+    indx "^0.2.3"
+    lodash.clone "^4.3.2"
+    lodash.defaults "^4.0.1"
+    lodash.flatten "^4.2.0"
+    lodash.merge "^4.4.0"
+    lodash.partialright "^4.1.4"
+    lodash.pick "^4.2.1"
+    lodash.uniq "^4.3.0"
+    resolve "^1.3.3"
+    semver "^5.3.0"
+    uglify-js "^2.8.22"
+    when "^3.7.8"
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -2196,7 +2215,7 @@ enhanced-resolve@~0.9.0:
     memory-fs "^0.2.0"
     tapable "^0.1.8"
 
-errno@^0.1.3:
+errno@^0.1.1, errno@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -3326,6 +3345,17 @@ gulp-imagemin@^3.3.0:
     imagemin-optipng "^5.2.1"
     imagemin-svgo "^5.2.2"
 
+gulp-less@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/gulp-less/-/gulp-less-3.3.2.tgz#f6636adcc66150a8902719fa59963fc7f862a49a"
+  dependencies:
+    accord "^0.27.3"
+    gulp-util "^3.0.7"
+    less "2.6.x || ^2.7.1"
+    object-assign "^4.0.1"
+    through2 "^2.0.0"
+    vinyl-sourcemaps-apply "^0.2.0"
+
 gulp-livereload@^3.8.1:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/gulp-livereload/-/gulp-livereload-3.8.1.tgz#00f744b2d749d3e9e3746589c8a44acac779b50f"
@@ -3698,6 +3728,10 @@ ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
+image-size@~0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+
 imagemin-gifsicle@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz#3781524c457612ef04916af34241a2b42bfcb40a"
@@ -3777,6 +3811,10 @@ indexes-of@^1.0.1:
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
+
+indx@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/indx/-/indx-0.2.3.tgz#15dcf56ee9cf65c0234c513c27fbd580e70fbc50"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -4285,6 +4323,19 @@ ldjson-stream@^1.2.1:
     split2 "^0.2.1"
     through2 "^0.6.1"
 
+"less@2.6.x || ^2.7.1":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/less/-/less-2.7.3.tgz#cc1260f51c900a9ec0d91fb6998139e02507b63b"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    mime "^1.2.11"
+    mkdirp "^0.5.0"
+    promise "^7.1.1"
+    request "2.81.0"
+    source-map "^0.5.3"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -4449,11 +4500,19 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
 lodash.escape@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-3.2.0.tgz#995ee0dc18c1b48cc92effae71a10aab5b487698"
   dependencies:
     lodash._root "^3.0.0"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -4495,9 +4554,21 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.merge@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
 lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
+lodash.partialright@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.partialright/-/lodash.partialright-4.2.1.tgz#0130d80e83363264d40074f329b8a3e7a8a1cc4b"
+
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.restparam@^3.0.0:
   version "3.6.1"
@@ -4528,7 +4599,7 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
-lodash.uniq@^4.5.0:
+lodash.uniq@^4.3.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
@@ -4757,6 +4828,10 @@ mime@1.3.4:
 "mime@>= 0.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.0.3.tgz#4353337854747c48ea498330dc034f9f4bbbcc0b"
+
+mime@^1.2.11:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -6189,6 +6264,12 @@ resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.3.3:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
+  dependencies:
+    path-parse "^1.0.5"
+
 resp-modifier@6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/resp-modifier/-/resp-modifier-6.0.2.tgz#b124de5c4fbafcba541f48ffa73970f4aa456b4f"
@@ -7118,7 +7199,7 @@ ua-parser-js@0.7.12:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.8.29:
+uglify-js@^2.8.22, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -7515,6 +7596,10 @@ weinre@^2.0.0-pre-I0Z7U9OV:
     express "2.5.x"
     nopt "3.0.x"
     underscore "1.7.x"
+
+when@^3.7.8:
+  version "3.7.8"
+  resolved "https://registry.yarnpkg.com/when/-/when-3.7.8.tgz#c7130b6a7ea04693e842cdc9e7a1f2aa39a39f82"
 
 whet.extend@~0.9.9:
   version "0.9.9"

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -81,6 +81,11 @@ class BuildCmd extends NodeCommandBase {
         if (file_exists($addonJsonPath)) {
             $addonJson = json_decode(file_get_contents($addonJsonPath), true);
 
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                CliUtil::write("\n\nThere were some issues parsing your addon.json file. Please ensure that it is valid JSON");
+                CliUtil::error("\nError Type: ".json_last_error_msg());
+            }
+
             // Get the build key and map the old key name
             if (array_key_exists('build', $addonJson)) {
                 $this->buildConfig = array_merge($this->buildConfig, $addonJson['build']);

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -21,7 +21,7 @@ class BuildCmd extends NodeCommandBase {
     /** @var string  */
     protected $buildToolBaseDirectory;
 
-    /** @var array The build configuration options
+    /** @var array The build configuration options.
      *
      * - processVersion: 'legacy' | '1.0'
      * - cssTool: 'scss' | 'less'
@@ -34,7 +34,7 @@ class BuildCmd extends NodeCommandBase {
     /**
      * BuildCmd constructor.
      *
-     * @param Cli $cli The CLI instance
+     * @param Cli $cli The CLI instance.
      */
     public function __construct(Cli $cli) {
         parent::__construct($cli);
@@ -93,7 +93,7 @@ class BuildCmd extends NodeCommandBase {
     /**
      * Determine build options passed as args. These override anything else.
      *
-     * @param Args $args The CLI arguments
+     * @param Args $args The CLI arguments.
      */
     protected function getBuildOptionsFromArgs(Args $args) {
         $processArg = $args->getOpt('process') ?: false;
@@ -109,11 +109,11 @@ class BuildCmd extends NodeCommandBase {
     }
 
     /**
-     * Validate that options passed are compatible with each other
+     * Validate that options passed are compatible with each other.
      *
      * Currently checks
-     * - that `--csstool` is v1 only.
-     * - Maps `processVersion` 1.0 -> v1
+     * - that csstool is v1 only.
+     * - Maps `processVersion` 1.0 -> v1.
      *
      * @param Args $args
      */
@@ -134,7 +134,7 @@ class BuildCmd extends NodeCommandBase {
     }
 
     /**
-     * Return all of the current build process versions
+     * Return all of the current build process versions.
      *
      * @return array The directory names
      */
@@ -148,9 +148,9 @@ class BuildCmd extends NodeCommandBase {
     }
 
     /**
-     * Get the directory of the build process to execute
+     * Get the directory of the build process to execute.
      *
-     * @param string $processVersion The arguments from the CLI
+     * @param string $processVersion The arguments from the CLI.
      *
      * @return string
      */


### PR DESCRIPTION
Depends on #35. Will need a rebase before review.

Fulfills #36.

This PR adds less stylesheet support through an additional `cssTool` property of the `build` key in the addon.json. It also supports specifying the `--csstool` argument.

The BuildCmd's logic for determined which options to use has been cleaned up to accomodate this. It is not made up of 3 distinct parts:

- Checking the addon.json for options
- Checking the CLI options/arguments for options
- Validating that the selected options are compatible with each other.