### PR TITLE
Fix errors in the linting process

### DIFF
--- a/src/NodeTools/Linter/configs/.eslintrc
+++ b/src/NodeTools/Linter/configs/.eslintrc
@@ -80,7 +80,6 @@
         "guard-for-in": 1,
         "no-alert": "error",
         "no-extend-native": "error",
-        "no-invalid-this": "error",
         "no-loop-func": 1,
         "no-multi-spaces": 1,
         "no-new-func": 1,

--- a/src/NodeTools/Linter/vanilla-fix-scripts.js
+++ b/src/NodeTools/Linter/vanilla-fix-scripts.js
@@ -22,7 +22,12 @@ module.exports = fixScripts;
  */
 async function fixScripts(files, eslintOptions) {
     const cli = new CLIEngine(eslintOptions);
-    const report = cli.executeOnFiles(files);
+
+    const filesWithoutStyles = files.filter(fileName => {
+        return !/.scss$/.test(fileName)
+    });
+
+    const report = cli.executeOnFiles(filesWithoutStyles);
 
     if (report && (report.errorCount > 0 || report.warningCount > 0)) {
 

--- a/src/NodeTools/Linter/vanilla-lint-scripts.js
+++ b/src/NodeTools/Linter/vanilla-lint-scripts.js
@@ -21,8 +21,11 @@ module.exports = lintScripts;
  */
 async function lintScripts(files, eslintOptions) {
     const eslint = new CLIEngine(eslintOptions);
+    const filesWithoutStyles = files.filter(fileName => {
+        return !/.scss$/.test(fileName)
+    });
 
-    const report = eslint.executeOnFiles(files);
+    const report = eslint.executeOnFiles(filesWithoutStyles);
     const formatter = eslint.getFormatter("stylish");
 
     print("\nJavascript Lint Results:");

--- a/src/NodeTools/Linter/vanilla-lint.js
+++ b/src/NodeTools/Linter/vanilla-lint.js
@@ -83,7 +83,7 @@ startProcess()
  *
  * @async
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
 async function startProcess() {
     if (options.shouldLintStyles) {


### PR DESCRIPTION
The javascript linting process wasn't preperly ignoring stylesheets due to it automatically expanding the glob and not using the ignore file. This PR manually filters out the scss glob (because I only want there to be 1 glob list). Stylelint properly filters out invalid extensions though so that is not necessary for that part of the process.

I also removed 1 eslint rule from the template that was too overbearing.