### PR TITLE
Check that live reload port is available.

### DIFF
--- a/src/NodeTools/BuildProcess/core/vanilla-build-core.js
+++ b/src/NodeTools/BuildProcess/core/vanilla-build-core.js
@@ -12,7 +12,7 @@ const livereload = require("gulp-livereload");
 
 const buildScripts = require("./build-scripts");
 const buildStyles = require("./build-styles");
-const { print, printError, spawnChildProcess } = require("../../library/utility");
+const { print, printError, spawnChildProcess, checkLiveReloadPort } = require("../../library/utility");
 
 const options = getOptions();
 installNodeModules(options)
@@ -103,13 +103,9 @@ async function run(options) {
     const promises = [buildScripts.run(options), buildStyles(options)];
 
     if (options.watch) {
+        await checkLiveReloadPort();
         promises.push(startLiveReload(primaryDirectory));
     }
 
-    return Promise.all(promises)
-        .then(() => {
-            if (options.watch) {
-                startLiveReload(primaryDirectory);
-            }
-        });
+    return Promise.all(promises).then(() => {});
 }

--- a/src/NodeTools/BuildProcess/v1/vanilla-build-v1.js
+++ b/src/NodeTools/BuildProcess/v1/vanilla-build-v1.js
@@ -9,7 +9,7 @@ const livereload = require("gulp-livereload");
 const argv = require("yargs").argv;
 const chalk = require("chalk").default;
 
-const { print, sleep } = require("../../library/utility");
+const { print, sleep, checkLiveReloadPort } = require("../../library/utility");
 
 const buildJs = require("./build.javascript");
 const buildStyles = require("./build.stylesheets");
@@ -52,27 +52,29 @@ gulp.task("build:assets", buildAssets(primaryDirectory, options.buildOptions));
 gulp.task("build", ["build:assets", "build:styles", "build:js"]);
 
 gulp.task("watch", ["build"], () => {
-    livereload.listen();
+    checkLiveReloadPort().then(() => {
+        livereload.listen();
 
-    const onReload = file => livereload.changed(file.path);
+        const onReload = file => livereload.changed(file.path);
 
-    gulp.watch(
-        [
-            path.resolve(primaryDirectory, "design/*.css"),
-            path.resolve(primaryDirectory, "design/images/**/*"),
-            path.resolve(primaryDirectory, "js/*.js"),
-            path.resolve(primaryDirectory, "views/**/*")
-        ],
-        onReload
-    );
+        gulp.watch(
+            [
+                path.resolve(primaryDirectory, "design/*.css"),
+                path.resolve(primaryDirectory, "design/images/**/*"),
+                path.resolve(primaryDirectory, "js/*.js"),
+                path.resolve(primaryDirectory, "views/**/*")
+            ],
+            onReload
+        );
 
-    const { cssTool } = options.buildOptions;
+        const { cssTool } = options.buildOptions;
 
-    gulp.watch(path.resolve(primaryDirectory, `src/**/*.${cssTool}`), ["build:styles"]);
-    gulp.watch(path.resolve(primaryDirectory, "src/**/*.js"), ["build:js"]);
-    gulp.watch(path.resolve(primaryDirectory, "design/images/**/*"), ["build:assets"]);
+        gulp.watch(path.resolve(primaryDirectory, `src/**/*.${cssTool}`), ["build:styles"]);
+        gulp.watch(path.resolve(primaryDirectory, "src/**/*.js"), ["build:js"]);
+        gulp.watch(path.resolve(primaryDirectory, "design/images/**/*"), ["build:assets"]);
 
-    print("\n" + chalk.green("Watching for changes in src files..."));
+        print("\n" + chalk.green("Watching for changes in src files..."));
+    })
 });
 
 const taskToExecute = options.watch ? "watch" : "build";

--- a/src/NodeTools/library/utility.js
+++ b/src/NodeTools/library/utility.js
@@ -7,6 +7,7 @@
 const path = require("path");
 const fs = require("fs");
 const chalk = require('chalk').default;
+const detectPort = require("detect-port");
 const { spawn } = require("child_process");
 
 module.exports = {
@@ -18,6 +19,7 @@ module.exports = {
     sleep,
     getJsonFileForDirectory,
     camelize,
+    checkLiveReloadPort,
 };
 
 const defaultSpawnOptions = {
@@ -153,4 +155,19 @@ function sleep(milliseconds) {
             resolve();
         }, milliseconds)
     })
+}
+
+async function checkLiveReloadPort() {
+    const port = 35729;
+
+    try {
+        const portResult = await detectPort(port);
+        if (portResult === port) {
+            return;
+        } else {
+            fail(`Unable to start LiveReload server. Port ${port} is currently in use. You likely have another build tool currently in watch mode. Quit that process, then try running this command again.`);
+        }
+    } catch (err) {
+        fail(err);
+    }
 }

--- a/src/NodeTools/package.json
+++ b/src/NodeTools/package.json
@@ -19,6 +19,7 @@
         "chokidar": "^1.7.0",
         "cross-spawn": "^5.1.0",
         "del": "^3.0.0",
+        "detect-port": "^1.2.2",
         "eslint": "^4.12.1",
         "eslint-config-vanillaforums": "^1.0.1",
         "eslint-filtered-fix": "^0.1.1",

--- a/src/NodeTools/package.json
+++ b/src/NodeTools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vanilla-cli-node-tools",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Node.js tooling for the Vanilla Cli.",
     "repository": "https://github.com/vanilla/vanilla-cli",
     "author": "Adam Charron <adam@charrondev.com>",

--- a/src/NodeTools/yarn.lock
+++ b/src/NodeTools/yarn.lock
@@ -175,6 +175,10 @@ acorn@^5.0.0, acorn@^5.0.3, acorn@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.2.1.tgz#317ac7821826c22c702d66189ab8359675f135d7"
 
+address@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
+
 ajv-keywords@^2.0.0, ajv-keywords@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz#617997fc5f60576894c435f940d819e135b80762"
@@ -2109,7 +2113,7 @@ debug-fabulous@>=0.1.1:
     memoizee "0.4.X"
     object-assign "4.X"
 
-debug@2.6.9, debug@^2.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
+debug@2.6.9, debug@^2.1.0, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -2312,6 +2316,13 @@ detect-libc@^1.0.2:
 detect-newline@2.X:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
+
+detect-port@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/detect-port/-/detect-port-1.2.2.tgz#57a44533632d8bc74ad255676866ca43f96c7469"
+  dependencies:
+    address "^1.0.1"
+    debug "^2.6.0"
 
 diff@^3.2.0:
   version "3.4.0"


### PR DESCRIPTION
Closes #44 

Checks if the port is available before starting a live reload server. If the port is already taken the process will fail with a message about the likely cause.