### PR TITLE
Fix bugs with v1 build process

### DIFF
--- a/src/NodeTools/BuildProcess/v1/build.javascript.js
+++ b/src/NodeTools/BuildProcess/v1/build.javascript.js
@@ -27,30 +27,22 @@ const { createBaseConfig } = require("../../library/webpack-utility");
 module.exports = (addonDirectory, options) => () => {
     let jsEntries = options.buildOptions.entries;
 
-    Object.keys(jsEntries).forEach(entryKey => {
-        const filePath = path.join(options.rootDirectories[0], 'src/js/index.js')
-        const prettyPath = filePath.replace(options.vanillaDirectory, '')
+    const expectedEntryPoint = "./index.js";
 
-        if (fs.existsSync(filePath)) {
-            print(chalk.yellow(`Using Entrypoint: ${prettyPath}`));
-            jsEntries[entryKey] = filePath;
-        } else {
-            // Don't throw if the "default" entry point is not found.
-            if (/src\/js\/index\.js/.test(filePath)) {
-                delete jsEntries[entryKey];
-            } else {
-                print(chalk.red(`Entrypoint provided but not found: ${prettyPath}`));
-                throw new Error();
-            }
-        }
-    });
+    if (Object.keys(jsEntries).length > 1 || jsEntries["custom"] !== expectedEntryPoint) {
+        printError("The build process v1 does not currently support custom entry points. \nhttps://docs.vanillaforums.com/developer/vanilla-cli/build-process-v1/#javascript\n\nFor custom entrypoints see the build process core.");
+        return;
+    }
 
-    if (Object.keys(jsEntries).length === 0) {
-        jsEntries = {};
+    if (!fs.existsSync(path.join(addonDirectory, 'src/js', expectedEntryPoint))) {
+        print(chalk.yellowBright("Javascript entrypoint src/js/index.js not found. Skipping JS build."));
+        return;
     }
 
     const v1Config = {
-        entry: jsEntries,
+        entry: {
+            custom: path.resolve(addonDirectory, "./src/js/index.js")
+        },
         output: {
             filename: "[name].js"
         }

--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -63,7 +63,7 @@ function createBaseConfig(buildRoot, isDevMode, shouldUglifyProd = true) {
             ]
         },
         resolve: {
-            modules: [path.join(buildRoot, "node_modules")],
+            modules: [path.join(buildRoot, "node_modules"), "node_modules"],
             extensions: [".js", ".jsx"]
         },
 
@@ -73,7 +73,7 @@ function createBaseConfig(buildRoot, isDevMode, shouldUglifyProd = true) {
          * We are expecting this tool to be used in a different directory than itself.
          */
         resolveLoader: {
-            modules: [path.resolve(__dirname, "../node_modules"), "node_modules"]
+            modules: [path.resolve(__dirname, "../node_modules")]
         },
         output: {
             filename: "[name].js"

--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -73,7 +73,7 @@ function createBaseConfig(buildRoot, isDevMode, shouldUglifyProd = true) {
          * We are expecting this tool to be used in a different directory than itself.
          */
         resolveLoader: {
-            modules: [path.resolve(__dirname, "../node_modules")]
+            modules: [path.resolve(__dirname, "../node_modules"), "node_modules"]
         },
         output: {
             filename: "[name].js"


### PR DESCRIPTION
## Simplify logic for v1 entry point

There was initially some messy logic for what the entry point was, because there initially was a desire to have the v1 allow it. That idea ended up being scrapped and a separate process was made for backwards compatibility. This change strictly hard codes what the value should be and add's some warnings if the entry point it not found or a different one is passed.

## Allow node module resolution to occur in all node_modules folders

The node module resolution was too strict, only checking the direct folders of the addon being built. Sometimes there are nested node_modules folders. This change allows for that, but will attempt to resolve directly in the addon's node_modules first.