### PR TITLE
Filter dependency bundles by entryKey

### DIFF
--- a/src/NodeTools/library/utility.js
+++ b/src/NodeTools/library/utility.js
@@ -91,12 +91,10 @@ function pluralize(word, count) {
  * @returns {string}
  */
 function camelize(str) {
-    const regex = /(?:^\w|[A-Z]|\b\w)/g;
-
-    return str.replace(regex, (letter, index) => {
-      return index == 0 ? letter.toLowerCase() : letter.toUpperCase();
-    }).replace(/\s+/g, '');
-  }
+    return str.replace(/[_.-](\w|$)/g, (substring, word) => {
+        return word.toUpperCase();
+    });
+}
 
 /**
  * Log something to STDOUT. Use this instead of console.log();

--- a/src/NodeTools/types.d.ts
+++ b/src/NodeTools/types.d.ts
@@ -6,8 +6,8 @@ interface BuildOptions {
     buildOptions: {
         process: 'legacy' | '1.0' | 'core';
         cssTool: 'scss' | 'less';
-        entries?: StringToStringObject | string[];
-        exports?: StringToStringObject | string[];
+        entries?: StringToStringObject;
+        exports?: StringToStringObject;
     };
     addonKey?: string;
     vanillaDirectory: string;


### PR DESCRIPTION
The entry bundles were being built against _all_ dependency bundles, even if they from a different section, leading to an error in the admin section. This PR fixes that by splitting out builds by individual entry and separating the entry bundles to match against only their own section.

eg.

```
app => app-manifest.json
admin => admin-manifest.json
```

The exception here is the bootstrap file which should more loosely match the manifest name.

```
bootstrap-app => app-manifest.json
bootstrap-admin => admin-manifest.json
```