### PR TITLE
Use entryKey for chunkNames so chunks don't override each other

### DIFF
--- a/src/NodeTools/BuildProcess/core/build-scripts.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts.js
@@ -114,7 +114,7 @@ async function createExportsConfig(primaryDirectory, options) {
             output: {
                 path: path.join(primaryDirectory, "js"),
                 filename: `[name]/lib-${options.addonKey}-[name].js`,
-                chunkFilename: `chunk/[name].js`,
+                chunkFilename: `chunk/[name]-${exportKey}.js`,
                 publicPath: getChunkPublicPath(options),
                 library: libraryName
             },
@@ -195,7 +195,7 @@ async function createEntriesConfig(primaryDirectory, options) {
                 path: path.join(primaryDirectory, "js"),
                 filename: `[name]/${options.addonKey}-[name].js`,
                 publicPath: getChunkPublicPath(options),
-                chunkFilename: `chunk/[name].js`,
+                chunkFilename: `chunk/[name]-${entryKey}.js`,
                 library: camelize(options.addonKey) + "_" + camelize(entryKey), // Needed to allow multiple webpack builds in one page.
             },
             resolve: {


### PR DESCRIPTION
The chunk names for dynamic import could override each other if the same files was being built from multiple bundles. This PR appends the entry key to the file name so these files don't overwrite each other.