### PR TITLE
Allow hot reloading for core javascript process

### DIFF
--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -1,0 +1,169 @@
+/**
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+const glob = require("glob");
+const webpack = require("webpack");
+const merge = require("webpack-merge");
+const express = require("express");
+const chalk = require("chalk").default;
+const devMiddleware = require("webpack-dev-middleware");
+const hotMiddleware = require("webpack-hot-middleware");
+
+const {
+    createBaseConfig,
+    getAliasesForRequirements,
+} = require("../../library/webpack-utility");
+const {
+    print,
+    printError,
+    getAllCoreBuildEntries,
+    fail,
+} = require("../../library/utility");
+
+module.exports = {
+    run,
+};
+
+/**
+ * Build dynamic entrypoints for a subsection of the entries.
+ *
+ * @param {string[]} entryPoints - The entrypoints to build into a javascript file.
+ *
+ * @returns {string}
+ */
+function buildDynamicEntrypointForSection(entryPoints) {
+    return entryPoints
+        .map(entry => `import "${entry}";`)
+        .join("\n");
+}
+
+/**
+ * Build a webpack configuration for a subset of entries.
+ *
+ * @param {Object} entries - An Object of "sectionKey => string[]"
+ * @param {string} sectionKey - The section key to build a config for.
+ * @param {BuildOptions} options
+ */
+function buildConfigForSection(entries, sectionKey, options) {
+    if (!(sectionKey in entries)) {
+        fail(`Could not build section ${sectionKey}, as no addons have defined that section.`);
+    }
+    const filteredEntries = entries[sectionKey];
+    const dynamicEntryContents = buildDynamicEntrypointForSection(filteredEntries);
+
+    const tempDir = fs.mkdtempSync(os.tmpdir + path.sep);
+    const dynamicEntryPath = path.join(tempDir, `${sectionKey}.js`);
+    fs.writeFileSync(dynamicEntryPath, dynamicEntryContents, "utf8");
+
+    // Backdate the file by 10 seconds because https://github.com/webpack/watchpack/issues/25
+    const now = Date.now() / 1000;
+    const then = now - 10;
+    fs.utimesSync(dynamicEntryPath, then, then);
+
+    const baseConfig = createBaseConfig(options.vanillaDirectory, options);
+
+    const config = merge(baseConfig, {
+        name: sectionKey,
+        entry: {
+            [sectionKey]: [
+                require.resolve('webpack-hot-middleware/client')
+                + "?dynamicPublicPath=true"
+                + "&path=/__webpack_hmr"
+                + `&name=${sectionKey}`,
+                dynamicEntryPath,
+            ]
+        },
+        output: {
+            filename: `${sectionKey}-hot-bundle.js`,
+            chunkFilename: `[name]-${sectionKey}-hot-chunk.js`,
+            publicPath: "http://127.0.0.1:3030",
+        },
+        resolve: {
+            alias: getAliasesForRequirements(options, true),
+        },
+        plugins: [
+            new webpack.HotModuleReplacementPlugin(),
+        ],
+    });
+
+    const nodeModuleDirectories = glob.sync(path.join(options.vanillaDirectory, "**/node_modules"));
+
+    config.resolve.modules.unshift(
+        path.resolve(options.vanillaDirectory, "node_modules"),
+        path.resolve(options.vanillaDirectory, "applications/dashboard/node_modules"),
+        path.resolve(options.vanillaDirectory, "applications/vanilla/node_modules"),
+        ...nodeModuleDirectories,
+    );
+
+    return config;
+}
+
+/**
+ * Run the hot javascript build process.
+ *
+ * @param {BuildOptions} options
+ */
+function run(options) {
+    try {
+        const entries = getAllCoreBuildEntries(options);
+
+        let config;
+
+        if (options.section) {
+            config = [buildConfigForSection(entries, options.section, options)];
+        } else {
+            config = Object.keys(entries).map(entryKey => {
+                return buildConfigForSection(entries, entryKey, options);
+            });
+        }
+
+        const compiler = webpack(config);
+        const app = express();
+
+        // Print notice after first compile to edit your vanilla configuration.
+
+        let hasPrintedConfigNotice = false;
+
+        compiler.plugin("done", () => {
+            setTimeout(() => {
+                if (!hasPrintedConfigNotice) {
+                    print(
+                        "\nComplete hot reload setup by adding the following to your vanilla config file.\n" +
+                        chalk.yellowBright(`$Configuration["HotReload"]["Enable"] = true;`)
+                    );
+
+                    hasPrintedConfigNotice = true;
+                }
+            }, 100);
+        });
+
+        // Allow CORS
+        app.use(function(req, res, next) {
+            res.header("Access-Control-Allow-Origin", "*");
+            res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+            next();
+        });
+
+        app.use(devMiddleware(compiler, {
+            publicPath: "http://127.0.0.1:3030",
+        }));
+
+        app.use(hotMiddleware(compiler));
+
+        app.listen(3030, () => {
+            print("Dev server listening on port 3030.");
+        });
+
+    } catch (err) {
+        if (options.verbose) {
+            throw err;
+        } else {
+            printError(err);
+        }
+    }
+}

--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -74,7 +74,8 @@ function buildConfigForSection(entries, sectionKey, options) {
                 require.resolve('webpack-hot-middleware/client')
                 + "?dynamicPublicPath=true"
                 + "&path=/__webpack_hmr"
-                + `&name=${sectionKey}`,
+                + `&name=${sectionKey}`
+                + "&reload=true",
                 dynamicEntryPath,
             ]
         },

--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -125,23 +125,6 @@ function run(options) {
         const compiler = webpack(config);
         const app = express();
 
-        // Print notice after first compile to edit your vanilla configuration.
-
-        let hasPrintedConfigNotice = false;
-
-        compiler.plugin("done", () => {
-            setTimeout(() => {
-                if (!hasPrintedConfigNotice) {
-                    print(
-                        "\nComplete hot reload setup by adding the following to your vanilla config file.\n" +
-                        chalk.yellowBright(`$Configuration["HotReload"]["Enable"] = true;`)
-                    );
-
-                    hasPrintedConfigNotice = true;
-                }
-            }, 100);
-        });
-
         // Allow CORS
         app.use(function(req, res, next) {
             res.header("Access-Control-Allow-Origin", "*");
@@ -157,6 +140,11 @@ function run(options) {
 
         app.listen(3030, () => {
             print("Dev server listening on port 3030.");
+
+            print(
+                "Complete hot reload setup by adding the following to your vanilla config file.\n" +
+                chalk.bold.yellowBright(`$Configuration["HotReload"]["Enable"] = true;\n`)
+            );
         });
 
     } catch (err) {

--- a/src/NodeTools/BuildProcess/core/build-scripts.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts.js
@@ -18,10 +18,8 @@ const {
 const {
     print,
     printError,
-    printVerbose,
-    spawnChildProcess,
+    fail,
     getJsonFileForDirectory,
-    sleep,
     camelize
 } = require("../../library/utility");
 
@@ -29,10 +27,7 @@ const {
 module.exports = {
     run,
     getManifestPathsForDirectory,
-    createExportsConfig,
     isValidEntryPoint,
-    createEntriesConfig,
-    runSingleWebpackConfig
 };
 
 /**

--- a/src/NodeTools/BuildProcess/core/vanilla-build-core.js
+++ b/src/NodeTools/BuildProcess/core/vanilla-build-core.js
@@ -40,9 +40,9 @@ function getOptions() {
     // @ts-ignore
     global.verbose = options.verbose;
 
-    const devModeWarning = chalk.bold.yellow(`WARNING The process is starting in watch/dev mode. Be sure to run a production build before commiting your changes by running this command without the '--watch' option.\n`);
+    const devModeWarning = chalk.bold.yellow(`WARNING The process is starting in watch/dev/hot mode. Be sure to run a production build before commiting your changes by running this command without the '--watch' or '--hot' option.\n`);
 
-    options.watch && print(devModeWarning);
+    (options.watch || options.hot) && print(devModeWarning);
 
     return options;
 }

--- a/src/NodeTools/BuildProcess/v1/build.javascript.js
+++ b/src/NodeTools/BuildProcess/v1/build.javascript.js
@@ -48,7 +48,7 @@ module.exports = (addonDirectory, options) => () => {
         }
     };
 
-    const baseConfig = createBaseConfig(addonDirectory, options.watch);
+    const baseConfig = createBaseConfig(addonDirectory, options);
     const finalConfig = merge(baseConfig, v1Config);
 
     return gulp

--- a/src/NodeTools/__tests__/build-core-scripts.test.js
+++ b/src/NodeTools/__tests__/build-core-scripts.test.js
@@ -27,7 +27,10 @@ const baseOptions = {
     },
     vanillaDirectory: path.resolve(__dirname, "./fixtures/vanilla/"),
     watch: false,
-    verbose: false
+    verbose: false,
+    enabledAddonKeys: [
+        "dashboard",
+    ]
 };
 
 function buildCoreWithOptions() {

--- a/src/NodeTools/library/utility.js
+++ b/src/NodeTools/library/utility.js
@@ -245,6 +245,10 @@ function getAllCoreBuildEntries(options) {
         const addonJson = getJsonFileForDirectory(coreAddonPath, "addon");
         const { entries } = addonJson.build;
 
+        if (!entries) {
+            return;
+        }
+
         for (let [entryKey, entryPath] of Object.entries(entries)) {
             // Special handling for bootstrap files.
             if (entryKey.includes("bootstrap")) {

--- a/src/NodeTools/library/utility.js
+++ b/src/NodeTools/library/utility.js
@@ -6,9 +6,9 @@
 
 const path = require("path");
 const fs = require("fs");
-const chalk = require('chalk').default;
+const chalk = require("chalk").default;
 const detectPort = require("detect-port");
-const { spawn } = require("child_process");
+const {spawn} = require("child_process");
 const glob = require("glob");
 
 module.exports = {
@@ -63,7 +63,7 @@ async function spawnChildProcess(command, args, options = defaultSpawnOptions) {
 
         task.on("close", (code) => {
             if (code !== 0) {
-                reject(new Error(`command "${command} exited with a non-zero status code."`))
+                reject(new Error(`command "${command} exited with a non-zero status code."`));
             }
             return resolve(true);
         });
@@ -156,8 +156,8 @@ function sleep(milliseconds) {
     return new Promise(resolve => {
         setTimeout(() => {
             resolve();
-        }, milliseconds)
-    })
+        }, milliseconds);
+    });
 }
 
 /**
@@ -191,7 +191,7 @@ let cachedCoreBuildAddons;
  * @returns {string[]} - An array of filepaths.
  */
 function getAllCoreBuildAddons(options) {
-    const { vanillaDirectory } = options;
+    const {vanillaDirectory} = options;
 
     if (cachedCoreBuildAddons) {
         return cachedCoreBuildAddons;
@@ -243,7 +243,7 @@ function getAllCoreBuildEntries(options) {
 
     coreAddonPaths.forEach(coreAddonPath => {
         const addonJson = getJsonFileForDirectory(coreAddonPath, "addon");
-        const { entries } = addonJson.build;
+        const {entries} = addonJson.build;
 
         if (!entries) {
             return;

--- a/src/NodeTools/package.json
+++ b/src/NodeTools/package.json
@@ -54,6 +54,8 @@
         "stylelint-scss": "^2.1.0",
         "uglifyjs-webpack-plugin": "^1.1.4",
         "webpack": "^3.10.0",
+        "webpack-dev-middleware": "^2.0.4",
+        "webpack-hot-middleware": "^2.21.0",
         "webpack-merge": "^4.1.1",
         "webpack-stream": "^4.0.0",
         "yargs": "^10.0.3"
@@ -71,6 +73,7 @@
     },
     "scripts": {
         "test": "jest",
+        "test:watch": "jest --watch",
         "test:dirty": "cross-env NO_CLEANUP=true jest"
     },
     "jest": {

--- a/src/NodeTools/types.d.ts
+++ b/src/NodeTools/types.d.ts
@@ -15,6 +15,9 @@ interface BuildOptions {
     requiredDirectories?: string[];
     watch: boolean;
     verbose: boolean;
+    hot: boolean;
+    section: string;
+    enabledAddonKeys: string[];
 }
 
 declare module "fs" {

--- a/src/NodeTools/yarn.lock
+++ b/src/NodeTools/yarn.lock
@@ -225,6 +225,10 @@ ansi-gray@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
+ansi-html@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-0.2.1.tgz#0d8e946967a3d8143f93e24e298525fc1b2235f9"
@@ -4069,6 +4073,10 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
+html-entities@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
+
 html-tags@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
@@ -5490,7 +5498,7 @@ lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"
 
-log-symbols@^2.0.0:
+log-symbols@^2.0.0, log-symbols@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.1.0.tgz#f35fa60e278832b538dc4dddcbb478a45d3e3be6"
   dependencies:
@@ -5502,6 +5510,10 @@ logalot@^2.0.0:
   dependencies:
     figures "^1.3.5"
     squeak "^1.0.0"
+
+loglevelnext@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/loglevelnext/-/loglevelnext-1.0.3.tgz#0f69277e73bbbf2cd61b94d82313216bf87ac66e"
 
 longest-streak@^2.0.1:
   version "2.0.2"
@@ -5517,7 +5529,7 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-loud-rejection@^1.0.0:
+loud-rejection@^1.0.0, loud-rejection@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
   dependencies:
@@ -5786,6 +5798,10 @@ mime@1.4.1:
 mime@^1.2.11:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+
+mime@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.2.0.tgz#161e541965551d3b549fa1114391e3a3d55b923b"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -7046,7 +7062,7 @@ querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
-querystring@0.2.0:
+querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
@@ -7074,7 +7090,7 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-range-parser@~1.2.0:
+range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
@@ -8785,6 +8801,10 @@ urix@^0.1.0, urix@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
 
+url-join@^2.0.2:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-2.0.5.tgz#5af22f18c052a000a48d7b82c5e9c2e2feeda728"
+
 url-parse-lax@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
@@ -9023,6 +9043,36 @@ webidl-conversions@^3.0.0:
 webidl-conversions@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
+webpack-dev-middleware@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-2.0.4.tgz#7d8943a609121021bb72772a41636e229346cb41"
+  dependencies:
+    loud-rejection "^1.6.0"
+    memory-fs "~0.4.1"
+    mime "^2.1.0"
+    path-is-absolute "^1.0.0"
+    range-parser "^1.0.3"
+    url-join "^2.0.2"
+    webpack-log "^1.0.1"
+
+webpack-hot-middleware@^2.21.0:
+  version "2.21.0"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.21.0.tgz#7b3c113a7a4b301c91e0749573c7aab28b414b52"
+  dependencies:
+    ansi-html "0.0.7"
+    html-entities "^1.2.0"
+    querystring "^0.2.0"
+    strip-ansi "^3.0.0"
+
+webpack-log@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/webpack-log/-/webpack-log-1.1.1.tgz#a0c7beb385245da7b2172afe46c02cf3a471ef31"
+  dependencies:
+    chalk "^2.1.0"
+    log-symbols "^2.1.0"
+    loglevelnext "^1.0.1"
+    uuid "^3.1.0"
 
 webpack-merge@^4.1.1:
   version "4.1.1"

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -211,7 +211,7 @@ class BuildCmd extends NodeCommandBase {
      * @return array
      */
     protected function getEnabledAddonKeys() {
-        $filePath = $this->vanillaSrcDir.'/conf/config.php';
+        $filePath = $this->vanillaSrcDir.'/conf/' . $this->configName;
         if (!file_exists($filePath)) {
             CliUtil::fail("Unable to locate Vanilla configuration at $filePath.");
         }

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -112,9 +112,9 @@ class BuildCmd extends NodeCommandBase {
     protected function setAddonJsonBuildOptions($rootDirectory = null) {
         if (!$rootDirectory) {
             $rootDirectory = getcwd();
+        } else {
+            $rootDirectory = $this->resolveAddonLocationInVanilla(basename($rootDirectory));
         }
-
-        $rootDirectory = $this->resolveAddonLocationInVanilla(basename($rootDirectory));
 
         $addonJson = CliUtil::getAddonJsonForDirectory($rootDirectory);
 
@@ -211,10 +211,6 @@ class BuildCmd extends NodeCommandBase {
      * @return array
      */
     protected function getEnabledAddonKeys() {
-        if (!$this->hot) {
-            return [];
-        }
-
         $filePath = $this->vanillaSrcDir.'/conf/config.php';
         if (!file_exists($filePath)) {
             CliUtil::fail("Unable to locate Vanilla configuration at $filePath.");
@@ -369,10 +365,6 @@ class BuildCmd extends NodeCommandBase {
      * @return string The resolved addonPath.
      */
     function resolveAddonLocationInVanilla($addonKey) {
-        if ($addonKey === basename($this->vanillaSrcDir)) {
-            return $this->vanillaSrcDir;
-        }
-
         $possiblePaths = [
             $this->vanillaSrcDir.'/addons/'.$addonKey,
             $this->vanillaSrcDir.'/applications/'.$addonKey,

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -233,8 +233,8 @@ class BuildCmd extends NodeCommandBase {
         }
 
         if (valr("EnabledApplications", $Configuration)) {
-            foreach($Configuration["EnabledApplications"] as $appKey => $value) {
-                $result[] = $appKey;
+            foreach($Configuration["EnabledApplications"] as $arrayKey => $addonKey) {
+                $result[] = $addonKey;
             }
         }
 

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -11,8 +11,6 @@ use \Garden\Cli\Cli;
 use \Garden\Cli\Args;
 use \Garden\Cli\LogFormatter;
 use \Vanilla\Cli\CliUtil;
-use \Vanilla\Addon;
-use \Vanilla\AddonManager;
 
 /**
  * Class BuildCmd.
@@ -38,14 +36,20 @@ class BuildCmd extends NodeCommandBase {
         'exports' => [],
     ];
 
+    /** Whether or not to run in hot mode. */
+    private $watch = false;
+
+    /** @var boolean Whether or not to run in hot mode. */
+    private $hot = false;
+
+    /** @var string|null A section of entries to filter the hot process by. */
+    private $section = null;
+
     /** @var array An array of addon configurations to build with. */
     private $addonBuildConfigs = [];
 
     /** @var array An array of realpaths to roots of addons being built. */
     private $addonRootDirectories = [];
-
-    /** @var array An array of parent build configurations */
-    private $parentConfigs = [];
 
     /**
      * BuildCmd constructor.
@@ -56,6 +60,8 @@ class BuildCmd extends NodeCommandBase {
         parent::__construct($cli);
         $cli->description('Build frontend assets (scripts, stylesheets, and images).')
             ->opt('watch:w', 'Run the build process in watch mode. Best used with the livereload browser extension.', false, 'bool')
+            ->opt('hot:h', 'Use a webpack hot reloading server.', false, 'bool')
+            ->opt('section:s', 'Limit the webpack hot reloading server to a only a certain section of Vanilla. Usually "app" or "admin"')
             ->opt('process:p', 'Which version of the build process to use. This will override the one specified in the addon.json')
             ->opt('csstool:ct', 'Which CSS Preprocessor to use: Either `scss` or `less`. Defaults to `scss`', false, 'string');
 
@@ -84,9 +90,12 @@ class BuildCmd extends NodeCommandBase {
             'buildOptions' => $this->addonBuildConfigs[0],
             'rootDirectories' => $this->addonRootDirectories,
             'requiredDirectories' => $this->getRequiredAddonDirectories(),
-            'watch' => $args->getOpt('watch') ?: false,
+            'watch' => $this->watch,
+            'hot' => $this->hot,
+            'section' => $this->section,
             'vanillaDirectory' => $this->vanillaSrcDir,
             'addonKey' => CliUtil::getAddonJsonForDirectory(getcwd())["key"],
+            'enabledAddonKeys' => $this->getEnabledAddonKeys(),
         ];
 
         $this->spawnNodeProcessFromPackageMain(
@@ -170,7 +179,10 @@ class BuildCmd extends NodeCommandBase {
      */
     protected function setBuildOptionsFromArgs(Args $args) {
         $processArg = $args->getOpt('process') ?: false;
+        $hotArg = $args->getOpt('hot') ?: false;
+        $watchArg = $args->getOpt('watch') ?: false;
         $cssToolArg = $args->getOpt('csstool');
+        $sectionArg = $args->getOpt('section');
 
         if ($processArg) {
             $this->defaultConfigurationOptions['process'] = $processArg;
@@ -179,6 +191,58 @@ class BuildCmd extends NodeCommandBase {
         if ($cssToolArg) {
             $this->defaultConfigurationOptions['cssTool'] = $cssToolArg;
         }
+
+        if ($hotArg) {
+            $this->hot = $hotArg;
+        }
+
+        if($watchArg) {
+            $this->watch = $watch;
+        }
+
+        if ($sectionArg) {
+            $this->section = $sectionArg;
+        }
+    }
+
+    /**
+     * Get the keys of enabled themes, plugins, and applications.
+     *
+     * @return array
+     */
+    protected function getEnabledAddonKeys() {
+        if (!$this->hot) {
+            return [];
+        }
+
+        $filePath = $this->vanillaSrcDir.'/conf/config.php';
+        if (!file_exists($filePath)) {
+            CliUtil::fail("Unable to locate Vanilla configuration at $filePath.");
+        }
+
+        CliUtil::write("Using vanilla configuration at $filePath.");
+        define("APPLICATION", "App");
+        require_once($filePath);
+
+        $result = [];
+
+        if (valr("EnabledPlugins", $Configuration)) {
+            foreach($Configuration["EnabledPlugins"] as $pluginKey => $value) {
+                $result[] = $pluginKey;
+            }
+        }
+
+        if (valr("EnabledApplications", $Configuration)) {
+            foreach($Configuration["EnabledApplications"] as $appKey => $value) {
+                $result[] = $appKey;
+            }
+        }
+
+        if (valr("Garden.Theme", $Configuration)) {
+            $result[] = $Configuration["Garden"]["Theme"];
+        }
+
+        return $result;
     }
 
     /**
@@ -246,6 +310,14 @@ class BuildCmd extends NodeCommandBase {
                 ' - pass "-csstool="less" as an argument to the build command.'
             );
         }
+
+        if ($this->hot && !($finalBuildConfig['process'] === 'core')) {
+            CliUtil::fail("The '--hot' parameter is only available for the 'core' build process.");
+        }
+
+        if (!$this->hot && $this->section) {
+            CliUtil::fail("The '--section' parameter is only available with the '--hot' option.");
+        }
     }
 
     /**
@@ -295,7 +367,6 @@ class BuildCmd extends NodeCommandBase {
      * @param string $addonKey The key of the addon to lookup.
      *
      * @return string The resolved addonPath.
-     * @throws Exception If an addon cannot be resolved.
      */
     function resolveAddonLocationInVanilla($addonKey) {
         if ($addonKey === basename($this->vanillaSrcDir)) {

--- a/src/Vanilla/Cli/Command/Command.php
+++ b/src/Vanilla/Cli/Command/Command.php
@@ -20,6 +20,9 @@ class Command {
     /** @var string */
     protected $vanillaSrcDir;
 
+    /** @var string */
+    protected $configName = "config.php";
+
     /** @var bool */
     protected $isVerbose;
 
@@ -33,8 +36,10 @@ class Command {
             ->command($this->getName())
             ->opt(
                 'vanillasrc',
-                'Vanilla source folder. This parameter can be skipped if you set VANILLACLI_VANILLA_SRC_DIR in your environment variables.'
-            )
+                'Vanilla source folder. This parameter can be skipped if you set VANILLACLI_VANILLA_SRC_DIR in your environment variables.')
+            ->opt(
+                'configname',
+                'Vanilla configuration file. This should be inside of your vanilla src directory. Defaults to "config.php". This parameter can be skipped if you set VANILLACLI_VANILLA_CONFIG_NAME in your environment variables.')
             ->opt('verbose:v', 'Show additional output.', false, 'bool')
         ;
     }
@@ -65,6 +70,12 @@ class Command {
      */
     public function run(Args $args) {
         $this->isVerbose = $args->getOpt('verbose') ?: false;
+        $configName =  $args->getOpt('configname', getenv('VANILLACLI_VANILLA_CONFIG_NAME'));
+
+        if ($configName) {
+            $this->configName = $configName;
+        }
+
         $potentialSrcDirectory = $args->getOpt('vanillasrc', getenv('VANILLACLI_VANILLA_SRC_DIR'));
 
         if (!$potentialSrcDirectory) {

--- a/src/Vanilla/Cli/Command/NodeCommandBase.php
+++ b/src/Vanilla/Cli/Command/NodeCommandBase.php
@@ -199,7 +199,7 @@ class NodeCommandBase extends Command {
         if ($hasHadNodeUpdate) {
             $reason = "\nThis tool's dependencies were installed with Node.js version {$vanillaLockJson['nodeVersion']}"
                 ."\n    Current Node.js version is {$currentNodeVersion}"
-                ."\nNode process $displayName's dependencies will need to be reinstalled";
+                ."\nNode process $displayName's dependencies will need to be reinstalled\n";
 
             $this->deleteDependenciesForDirectory($directoryPath);
             $this->installDependenciesForDirectory($directoryPath, $reason);
@@ -208,7 +208,7 @@ class NodeCommandBase extends Command {
         if ($hasHadPackageUpdate) {
             $reason = "\nNode process $displayName's dependencies were installed for package version $installedVersion"
                 ."\n    Current package version is $packageVersion"
-                ."\nNode process $displayName's dependencies will need to be reinstalled";
+                ."\nNode process $displayName's dependencies will need to be reinstalled\n";
 
             $this->deleteDependenciesForDirectory($directoryPath);
             $this->installDependenciesForDirectory($directoryPath, $reason);
@@ -219,7 +219,7 @@ class NodeCommandBase extends Command {
             CliUtil::write(
                 "Skipping install for node process $displayName - Already installed"
                 ."\n    Installed Version - $installedVersion"
-                ."\n    Current Version - $packageVersion"
+                ."\n    Current Version - $packageVersion\n"
             );
         }
     }


### PR DESCRIPTION
Depends on #71, needs rebase after that is merged.

Closes #72 

Needs https://github.com/vanilla/vanilla/pull/6444

Allows webpack hot module reloading and uses webpack dev middleware for faster bundles. This hot reloading is enabled by adding the `--hot` flag to vanilla. Additionally the `--section` flag is added to allow specification of just "app" or "admin" section. If no section flag is provided all sections will be build in parallel and made available on the dev server.

All entrypoints of the same section get put together in 1 bundle. There "export" bundles. They are ignored because webpack will handle the deduplication itself in 1 bundle.

Having everything together and served from memory speeds up rebuilds significantly and fixes source maps which were a little wonky spread among so many different bundles.
