### PR TITLE
Fix hot reload url

### DIFF
--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -73,7 +73,7 @@ function buildConfigForSection(entries, sectionKey, options) {
             [sectionKey]: [
                 require.resolve('webpack-hot-middleware/client')
                 + "?dynamicPublicPath=true"
-                + "&path=/__webpack_hmr"
+                + "&path=__webpack_hmr"
                 + `&name=${sectionKey}`
                 + "&reload=true",
                 dynamicEntryPath,
@@ -82,7 +82,7 @@ function buildConfigForSection(entries, sectionKey, options) {
         output: {
             filename: `${sectionKey}-hot-bundle.js`,
             chunkFilename: `[name]-${sectionKey}-hot-chunk.js`,
-            publicPath: "http://127.0.0.1:3030",
+            publicPath: "http://127.0.0.1:3030/",
         },
         resolve: {
             alias: getAliasesForRequirements(options, true),
@@ -134,7 +134,7 @@ function run(options) {
         });
 
         app.use(devMiddleware(compiler, {
-            publicPath: "http://127.0.0.1:3030",
+            publicPath: "http://127.0.0.1:3030/",
         }));
 
         app.use(hotMiddleware(compiler));

--- a/src/NodeTools/package.json
+++ b/src/NodeTools/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vanilla-cli-node-tools",
-    "version": "1.3.1",
+    "version": "1.4.0",
     "description": "Node.js tooling for the Vanilla Cli.",
     "repository": "https://github.com/vanilla/vanilla-cli",
     "author": "Adam Charron <adam@charrondev.com>",


### PR DESCRIPTION
Hot reloading wasn't working because the path was being joined incorrectly. It needs to have a trailing slash.

Also bumps package.json version.