### PR TITLE
Load config defaults

### DIFF
--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -211,8 +211,8 @@ class BuildCmd extends NodeCommandBase {
      * @return array
      */
     protected function getEnabledAddonKeys() {
-        $configPath = $this->vanillaSrcDir . '/conf/' . $this->configName;
-        $configDefaultsPath = $this->vanillaSrcDir . '/conf/config-defaults.php';
+        $configPath = $this->vanillaSrcDir.'/conf/'.$this->configName;
+        $configDefaultsPath = $this->vanillaSrcDir.'/conf/config-defaults.php';
         if (!file_exists($configPath)) {
             CliUtil::fail("Unable to locate Vanilla configuration at $configPath.");
         }

--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -211,14 +211,17 @@ class BuildCmd extends NodeCommandBase {
      * @return array
      */
     protected function getEnabledAddonKeys() {
-        $filePath = $this->vanillaSrcDir.'/conf/' . $this->configName;
-        if (!file_exists($filePath)) {
-            CliUtil::fail("Unable to locate Vanilla configuration at $filePath.");
+        $configPath = $this->vanillaSrcDir . '/conf/' . $this->configName;
+        $configDefaultsPath = $this->vanillaSrcDir . '/conf/config-defaults.php';
+        if (!file_exists($configPath)) {
+            CliUtil::fail("Unable to locate Vanilla configuration at $configPath.");
         }
 
-        CliUtil::write("Using vanilla configuration at $filePath.");
+        CliUtil::write("Using vanilla configuration at $configPath.");
         define("APPLICATION", "App");
-        require_once($filePath);
+        define("PATH_CACHE", "");
+        require_once($configDefaultsPath);
+        require_once($configPath);
 
         $result = [];
 


### PR DESCRIPTION
Fixes #82 

The PATH_CACHE is never used but is referenced in our default config so it needed to be defined.