### PR TITLE
Don't format with prettier in the hot build or watch mode

### DIFF
--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -180,7 +180,9 @@ function mergeTypescriptConfig(options, config, includedFiles) {
     const tsConfigFile = path.join(options.vanillaDirectory, "tsconfig.json");
     const tslintFile = path.join(options.vanillaDirectory, "tslint.json");
 
-    if (fs.existsSync(prettierFile)) {
+    const isNotWatchOrDevMode = !(options.watch || options.hot);
+
+    if (fs.existsSync(prettierFile) && isNotWatchOrDevMode) {
         const prettierConfig = require(prettierFile);
         config.plugins.unshift(new PrettierPlugin({
             ...prettierConfig,


### PR DESCRIPTION
It was quite problematic to format in the build tool when running in hot or watch mode. Filesystem conflicts were happening pretty often when making multiple intermediary saves while editing.

I've disabled it for now when the build runs with `--watch` or `--hot`.