### PR TITLE
Prevent the hard source plugin from using all CPU

### DIFF
--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -13,6 +13,7 @@ const express = require("express");
 const chalk = require("chalk").default;
 const devMiddleware = require("webpack-dev-middleware");
 const hotMiddleware = require("webpack-hot-middleware");
+const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 
 const {
     createBaseConfig,
@@ -66,6 +67,10 @@ function buildConfigForSection(entries, sectionKey, options) {
             alias: getAliasesForRequirements(options, true),
         },
         plugins: [
+            new HardSourceWebpackPlugin({
+                // Either an absolute path or relative to webpack's options.context.
+                cacheDirectory: path.normalize(path.join(__dirname, '../node_modules/.cache/hard-source/[confighash]')),
+            }),
             new webpack.HotModuleReplacementPlugin(),
         ],
     });

--- a/src/NodeTools/BuildProcess/core/build-scripts-hot.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts-hot.js
@@ -69,7 +69,7 @@ function buildConfigForSection(entries, sectionKey, options) {
         plugins: [
             new HardSourceWebpackPlugin({
                 // Either an absolute path or relative to webpack's options.context.
-                cacheDirectory: path.normalize(path.join(__dirname, '../node_modules/.cache/hard-source/[confighash]')),
+                cacheDirectory: path.normalize(path.join(__dirname, '../../node_modules/.cache/hard-source/[confighash]')),
             }),
             new webpack.HotModuleReplacementPlugin(),
         ],

--- a/src/NodeTools/BuildProcess/core/build-scripts.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts.js
@@ -42,7 +42,9 @@ async function run(options) {
         const exportsConfig = await createExportsConfig(primaryDirectory, options);
 
         if (exportsConfig) {
-            await runSingleWebpackConfig(exportsConfig, options);
+            for (const config of exportsConfig) {
+                await runSingleWebpackConfig(config, options);
+            }
         }
 
         // The entries config MUST be created after the first process has completed
@@ -50,7 +52,9 @@ async function run(options) {
         const entriesConfig = await createEntriesConfig(primaryDirectory, options);
 
         if (entriesConfig) {
-            await runSingleWebpackConfig(entriesConfig, options);
+            for (const config of entriesConfig) {
+                await runSingleWebpackConfig(config, options);
+            }
         }
     } catch (err) {
         printError(err);

--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -10,7 +10,6 @@ const merge = require("webpack-merge");
 const babelPreset = require("@vanillaforums/babel-preset");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 const PrettierPlugin = require("prettier-webpack-plugin");
-const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const HappyPack = require('happypack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const chalk = require("chalk").default;
@@ -101,10 +100,6 @@ function createBaseConfig(buildRoot, options, shouldUglifyProd = true) {
             extensions: [".ts", ".tsx", ".js", ".jsx", ".svg"]
         },
         plugins: [
-            new HardSourceWebpackPlugin({
-                // Either an absolute path or relative to webpack's options.context.
-                cacheDirectory: path.join(options.vanillaDirectory, 'node_modules/.cache/hard-source/[confighash]'),
-            }),
             new HappyPack({
                 id: 'babel',
                 verbose: options.verbose,

--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -13,6 +13,7 @@ const PrettierPlugin = require("prettier-webpack-plugin");
 const HappyPack = require('happypack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const chalk = require("chalk").default;
+const happyThreadPool = HappyPack.ThreadPool({ size: 4, id: "scripts" });
 
 const {
     printVerbose,
@@ -103,6 +104,7 @@ function createBaseConfig(buildRoot, options, shouldUglifyProd = true) {
             new HappyPack({
                 id: 'babel',
                 verbose: options.verbose,
+                threadPool: happyThreadPool,
                 rules: [
                     {
                         path: 'babel-loader',
@@ -190,6 +192,7 @@ function mergeTypescriptConfig(options, config, includedFiles) {
             new HappyPack({
                 id: 'ts',
                 verbose: options.verbose,
+                threadPool: happyThreadPool,
                 rules: [
                     {
                         path: 'ts-loader',


### PR DESCRIPTION
The hard source plugin is used to cache intermediary build files, but it caches a separate set for every new config. Each entry point in our production build has its own entry point and as a result a ton of intermediary cache files were getting written at once. This could easily overwhelm the CPU and crash running web servers, particularly if the cache files were written into the docker container.

Additionally the non-hot build process now builds one bundle at a time. Happypack results in faster build times per-bundle, but could quickly overwhelm the cpu when trying to spawn too many processes at once.

The babel and typescript loaders now share the same threadpool as well.