### PR TITLE
Reorganize script files

### DIFF
--- a/src/NodeTools/BuildProcess/core/build-scripts.js
+++ b/src/NodeTools/BuildProcess/core/build-scripts.js
@@ -98,7 +98,7 @@ async function createExportsConfig(primaryDirectory, options) {
         return;
     }
 
-    exports = preprocessWebpackExports(exports);
+    exports = preprocessWebpackExports(exports, primaryDirectory);
 
     // Remove this addon's libraries so it doesn't build it's own exports against it's own exports
     const self = options.rootDirectories[0];
@@ -241,11 +241,7 @@ function addonUsesCoreBuildProcess(directory) {
  * @param {BuildOptions} options
  */
 function getChunkPublicPath(options) {
-    const { addonKey } = options;
-    let basePath = (addonKey === "core") ? "" : `themes/${addonKey}/`;
-
-    const path = getPathFromVanillaRoot(options) + `js/`
-    return path;
+    return getPathFromVanillaRoot(options) + `js/`;
 }
 
 /**
@@ -254,7 +250,7 @@ function getChunkPublicPath(options) {
  * @param {BuildOptions} options
  */
 function getPathFromVanillaRoot(options) {
-    const { addonKey, rootDirectories, vanillaDirectory } = options;
+    const { rootDirectories, vanillaDirectory } = options;
     const root = rootDirectories[0].replace(vanillaDirectory, '/').replace("//", "/");
     if (root.endsWith("/")) {
         return root;

--- a/src/NodeTools/library/utility.js
+++ b/src/NodeTools/library/utility.js
@@ -197,10 +197,8 @@ function getAllCoreBuildAddons(options) {
         return cachedCoreBuildAddons;
     }
 
-    const addonJsonPaths = glob.sync(path.join(vanillaDirectory, "**/addon.json"));
-    addonJsonPaths.unshift(path.join(vanillaDirectory, "addon.json"));
-
-    cachedCoreBuildAddons = addonJsonPaths
+    cachedCoreBuildAddons =  glob
+        .sync(path.join(vanillaDirectory, "**/addon.json"))
         .filter(addonJsonPath => {
             const directory = path.dirname(addonJsonPath);
             const addonJson = getJsonFileForDirectory(directory, "addon");
@@ -214,10 +212,6 @@ function getAllCoreBuildAddons(options) {
         .map(path.dirname)
         .filter((item, index, self) => self.indexOf(item) == index)
         .filter(addonPath => {
-            if (addonPath === vanillaDirectory) {
-                return true;
-            }
-
             const addonKey = path.basename(addonPath);
 
             if (options.enabledAddonKeys.includes(addonKey)) {
@@ -226,6 +220,8 @@ function getAllCoreBuildAddons(options) {
                 return false;
             }
         });
+
+    cachedCoreBuildAddons.unshift(options.vanillaDirectory);
 
     return cachedCoreBuildAddons;
 }
@@ -242,6 +238,9 @@ function getAllCoreBuildEntries(options) {
     const coreBuildEntries = [];
 
     coreAddonPaths.forEach(coreAddonPath => {
+        if (!fs.existsSync(path.join(coreAddonPath, "addon.json"))) {
+            return;
+        }
         const addonJson = getJsonFileForDirectory(coreAddonPath, "addon");
         const {entries} = addonJson.build;
 

--- a/src/NodeTools/library/webpack-utility.js
+++ b/src/NodeTools/library/webpack-utility.js
@@ -10,6 +10,7 @@ const merge = require("webpack-merge");
 const babelPreset = require("@vanillaforums/babel-preset");
 const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
 const PrettierPlugin = require("prettier-webpack-plugin");
+const glob = require("glob");
 const HappyPack = require('happypack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const chalk = require("chalk").default;

--- a/src/Vanilla/Cli/CliUtil.php
+++ b/src/Vanilla/Cli/CliUtil.php
@@ -63,13 +63,40 @@ class CliUtil {
             $addonJson = json_decode(file_get_contents($addonJsonPath), true);
 
             if (json_last_error() !== JSON_ERROR_NONE) {
-                CliUtil::write("\n\nThere were some issues parsing your addon.json file. Please ensure that it is valid JSON");
-                CliUtil::fail("\nError Type: ".json_last_error_msg());
+                self::write("\n\nThere were some issues parsing your addon.json file. Please ensure that it is valid JSON");
+                self::fail("\nError Type: ".json_last_error_msg());
             }
 
             return $addonJson;
-        } else {
-            CliUtil::fail("No addon.json file was found. Make sure that you are in an addon's directory");
         }
+        self::fail("No addon.json file was found. Make sure that you are in an addon's directory");
+    }
+
+    /**
+     * Resolve the file path of an addon inside of vanilla.
+     *
+     * This is because we need a path inside of Vanilla, but some shells like fish automatically
+     * resolve symlinks. Many addons are symlinked into a vanilla for installation.
+     *
+     * @param string $vanillaRootDir The vanilla root directory.
+     * @param string $addonKey The key of the addon to lookup.
+     *
+     * @return string|null The resolved addonPath.
+     */
+    public static function resolveAddonLocationInVanilla($vanillaRootDir, $addonKey) {
+        $possiblePaths = [
+            $vanillaRootDir.'/addons/'.$addonKey,
+            $vanillaRootDir.'/applications/'.$addonKey,
+            $vanillaRootDir.'/plugins/'.$addonKey,
+            $vanillaRootDir.'/themes/'.$addonKey,
+        ];
+
+        foreach($possiblePaths as $path) {
+            if (\file_exists($path)) {
+                return $path;
+            }
+        }
+
+        self::fail("Could not find required addon $addonKey in your vanilla source directory ".$vanillaRootDir);
     }
 }

--- a/src/Vanilla/Cli/CliUtil.php
+++ b/src/Vanilla/Cli/CliUtil.php
@@ -71,32 +71,4 @@ class CliUtil {
         }
         self::fail("No addon.json file was found. Make sure that you are in an addon's directory");
     }
-
-    /**
-     * Resolve the file path of an addon inside of vanilla.
-     *
-     * This is because we need a path inside of Vanilla, but some shells like fish automatically
-     * resolve symlinks. Many addons are symlinked into a vanilla for installation.
-     *
-     * @param string $vanillaRootDir The vanilla root directory.
-     * @param string $addonKey The key of the addon to lookup.
-     *
-     * @return string|null The resolved addonPath.
-     */
-    public static function resolveAddonLocationInVanilla($vanillaRootDir, $addonKey) {
-        $possiblePaths = [
-            $vanillaRootDir.'/addons/'.$addonKey,
-            $vanillaRootDir.'/applications/'.$addonKey,
-            $vanillaRootDir.'/plugins/'.$addonKey,
-            $vanillaRootDir.'/themes/'.$addonKey,
-        ];
-
-        foreach($possiblePaths as $path) {
-            if (\file_exists($path)) {
-                return $path;
-            }
-        }
-
-        self::fail("Could not find required addon $addonKey in your vanilla source directory ".$vanillaRootDir);
-    }
 }


### PR DESCRIPTION
_note: This PR is failing travis because we just turned travis on and there is no travis file yet. One will be added later in this sprint._

Goes with: https://github.com/vanilla/vanilla/pull/7248

The dashboard is now the root addon in a vanilla installation and all the scripts have been moved there. 

To accomodate that, a few checks for the core addon (which no longer exists) were removed, and a couple were just replaced with the dashboard addon instead.

Additionally:

- Replaced a few `array_push` s with array concatenation. Apparently it's almost twice as fast in PHP.
- Instead of re-writing all of the tedious exports for the new structure, exports in the `addon.json` can take glob patterns now.