### PR TITLE
Fix hard-source-plugin cache path

### DIFF
--- a/src/build/core/hot.ts
+++ b/src/build/core/hot.ts
@@ -57,7 +57,7 @@ function buildConfigForSection(entries: IBuildEntries | IBuildExports, sectionKe
             new HardSourceWebpackPlugin({
                 // Either an absolute path or relative to webpack's options.context.
                 cacheDirectory: path.normalize(
-                    path.join(__dirname, "../../node_modules/.cache/hard-source/[confighash]"),
+                    path.join(__dirname, "../../../node_modules/.cache/hard-source/[confighash]"),
                 ),
             }),
             new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
The node modules (and cache are supposed to live the root of the repo.)