### PR TITLE
Allow configurable hot reload URL

### DIFF
--- a/src/Vanilla/Cli/Command/BuildCmd.php
+++ b/src/Vanilla/Cli/Command/BuildCmd.php
@@ -51,6 +51,9 @@ class BuildCmd extends NodeCommandBase {
     /** @var boolean Whether or not to run in hot mode. */
     private $hot = false;
 
+    /** @var string The IP to run the hot reload server on. */
+    private $hotReloadIP;
+
     /** @var string|null A section of entries to filter the hot process by. */
     private $section = null;
 
@@ -59,6 +62,8 @@ class BuildCmd extends NodeCommandBase {
 
     /** @var array An array of realpaths to roots of addons being built. */
     private $addonRootDirectories = [];
+
+    private $enabledAddonKeys = [];
 
     /**
      * BuildCmd constructor.
@@ -89,6 +94,7 @@ class BuildCmd extends NodeCommandBase {
         parent::run($args);
 
         $this->setBuildOptionsFromArgs($args);
+        $this->getVanillaConfigValues();
         $this->setAddonJsonBuildOptions();
         $this->setDefaultBuildOptions();
         $this->validateBuildOptions();
@@ -99,10 +105,11 @@ class BuildCmd extends NodeCommandBase {
             'requiredDirectories' => $this->getRequiredAddonDirectories(),
             'watch' => $this->watch,
             'hot' => $this->hot,
+            'hotReloadIP' => $this->hotReloadIP,
             'section' => $this->section,
             'vanillaDirectory' => $this->vanillaSrcDir,
             'addonKey' => $this->hot ? "dashboard" : CliUtil::getAddonJsonForDirectory(getcwd())["key"],
-            'enabledAddonKeys' => $this->getEnabledAddonKeys(),
+            'enabledAddonKeys' => $this->enabledAddonKeys,
             'skipPrettify' => $args->getOpt('skip-prettify') ?: false,
         ];
 
@@ -220,7 +227,7 @@ class BuildCmd extends NodeCommandBase {
      *
      * @return array
      */
-    protected function getEnabledAddonKeys() {
+    protected function getVanillaConfigValues() {
         $configPath = $this->vanillaSrcDir.'/conf/'.$this->configName;
         $configDefaultsPath = $this->vanillaSrcDir.'/conf/config-defaults.php';
         if (!file_exists($configPath)) {
@@ -251,7 +258,8 @@ class BuildCmd extends NodeCommandBase {
             $result[] = $Configuration["Garden"]["Theme"];
         }
 
-        return $result;
+        $this->enabledAddonKeys = $result;
+        $this->hotReloadIP = valr("HotReload.IP", $Configuration, "127.0.0.1");
     }
 
     /**

--- a/src/build/core/hot.ts
+++ b/src/build/core/hot.ts
@@ -48,7 +48,7 @@ function buildConfigForSection(entries: IBuildEntries | IBuildExports, sectionKe
         output: {
             filename: `${sectionKey}-hot-bundle.js`,
             chunkFilename: `[name]-${sectionKey}-hot-chunk.js`,
-            publicPath: "http://127.0.0.1:3030/",
+            publicPath: `http://${options.hotReloadIP}:3030/`,
         },
         resolve: {
             alias: getAliasesForRequirements(options, true),
@@ -106,7 +106,7 @@ export default function run(options: ICliOptions) {
 
         app.use(
             devMiddleware(compiler, {
-                publicPath: "http://127.0.0.1:3030/",
+                publicPath: `http://${options.hotReloadIP}:3030/`,
                 stats: {
                     chunks: false, // Makes the build much quieter
                     modules: false,
@@ -118,7 +118,7 @@ export default function run(options: ICliOptions) {
         app.use(hotMiddleware(compiler));
 
         app.listen(3030, () => {
-            print("Dev server listening on port 3030.");
+            print(`Dev server listening on port ${options.hotReloadIP}:3030.`);
 
             print(
                 "Complete hot reload setup by adding the following to your vanilla config file.\n" +

--- a/src/build/global.d.ts
+++ b/src/build/global.d.ts
@@ -11,6 +11,7 @@ interface ICliOptions {
     watch: boolean;
     verbose: boolean;
     hot: boolean;
+    hotReloadIP: string;
     section: string;
     enabledAddonKeys: string[];
     skipPrettify: boolean;


### PR DESCRIPTION
Closes https://github.com/vanilla/internal/issues/1599
Requires https://github.com/vanilla/vanilla/pull/7301

This PR allows for a configurable hot reload IP address for the hot reload process. I initially tried to automatically find this value, at which point it would just be default, but I was unable to get PHP and JS sides to agree on what the IP should be.

In the end I went with a Vanilla configuration value. Docs will come in a later PR.

## Setup

1. Locate your public local IP address for your system. On MacOS this can be found in `System Preferences -> Network`

![image](https://user-images.githubusercontent.com/1770056/40929690-872ff8d8-67f3-11e8-8184-b09b0fe9b92d.png)

2. Set the `HotReload.IP` configuration value to the IP address in your vanilla configuration. In my case this is

```php
// HotReload
$Configuration['HotReload']['Enabled'] = true;
$Configuration['HotReload']['IP'] = "10.1.1.65";
```

3. Restart the hot build process `vanilla build --hot`

4. Access your site through that same IP address (`http://10.1.1.65` or whatever you're IP is). This requires you're vanilla installation be the default server setup on port 80 of your localhost. This is already the case with the `vanilla-docker` setup.

This should work with:
- Local devices
- Browser stack

This will not work with
- `https://`