### PR TITLE
Exclude tests from export bundles

### DIFF
--- a/src/build/library/webpack-utility.ts
+++ b/src/build/library/webpack-utility.ts
@@ -236,7 +236,7 @@ export function preprocessWebpackExports(exports: IBuildExports, addonDirectory:
             }
 
             const resolvedPath = path.join(addonDirectory, item);
-            newItems = newItems.concat(glob.sync(resolvedPath));
+            newItems = newItems.concat(glob.sync(resolvedPath).filter(globItem => !globItem.match(/\.test\./)));
         });
 
         return newItems;


### PR DESCRIPTION
Our glob patterns were including test files that now live right next to the file itself. Since negative glob patterns are pain, I'm just excluding test files from being globbed in exports at all.