### PR TITLE
Fix alias calculation for production builds

### DIFF
--- a/src/build/library/webpack-utility.ts
+++ b/src/build/library/webpack-utility.ts
@@ -262,12 +262,10 @@ export function preprocessWebpackExports(exports: IBuildExports, addonDirectory:
  * @param forceAll - Force the function to make aliases for every single addon.
  */
 export function getAliasesForRequirements(options: ICliOptions, forceAll = false) {
-    const { vanillaDirectory, requiredDirectories } = options;
-    if (!requiredDirectories) {
-        return {};
-    }
+    const { vanillaDirectory, requiredDirectories, rootDirectories } = options;
+    const allDirectories = [...requiredDirectories, ...rootDirectories];
 
-    const allowedKeys = requiredDirectories.map(dir => {
+    const allowedKeys = allDirectories.map(dir => {
         return path.basename(dir);
     });
 


### PR DESCRIPTION
When determining what aliases to use, we were not including all necessary directories, preventing building addons with the `@rich-editor` or other plugin 
aliases. This only affected production builds as the hot build adds aliases for every addon.

This PR fixes this by creating a new array with all required and root directories.

To be honest the way the options are currently passed in is a bit of a mess, but I don't want to dive in too deep, until we do a larger simplification https://github.com/vanilla/vanilla-cli/issues/98.