### PR TITLE
Allow resolving in dashboard addon for scss imports

### DIFF
--- a/src/build/library/SassTool.ts
+++ b/src/build/library/SassTool.ts
@@ -30,12 +30,12 @@ export default class SassTool {
     ) => {
         const nodeModuleRegex = /^~/;
         const cssHttpImportRegex = /^((\/\/)|(http:\/\/)|(https:\/\/))/;
-        const scssRegex = /^@vanilla-root/;
+        const scssRegex = /^@dashboard/;
 
         let trueFilePath = "";
 
         if (url.match(scssRegex)) {
-            trueFilePath = url.replace(scssRegex, this.vanillaDirectory);
+            trueFilePath = url.replace(scssRegex, path.join(this.vanillaDirectory, "applications/dashboard"));
             printVerbose(`Mapping request SCSS import ${chalk.yellow(url)} to ${trueFilePath}`);
         } else if (url.match(cssHttpImportRegex)) {
             // Ensure the file name is wrapped in quotes or we'll break the native css @import

--- a/src/build/library/SassTool.ts
+++ b/src/build/library/SassTool.ts
@@ -9,7 +9,7 @@ import chalk from "chalk";
 import { print, printVerbose, printError } from "./utility";
 
 export default class SassTool {
-    constructor(private sourceDirectories: string[]) {}
+    constructor(private sourceDirectories: string[], private vanillaDirectory: string) {}
 
     /**
      * Create a custom Sass importer to search node modules folder with ~ prefix.
@@ -19,7 +19,7 @@ export default class SassTool {
      * @param prev - The previous filepath.
      * @param {function} done - Completion callback.
      */
-    public importer(
+    public importer = (
         url: string,
         prev: string,
         done: (
@@ -27,13 +27,17 @@ export default class SassTool {
                 file: string;
             },
         ) => void,
-    ) {
+    ) => {
         const nodeModuleRegex = /^~/;
         const cssHttpImportRegex = /^((\/\/)|(http:\/\/)|(https:\/\/))/;
+        const scssRegex = /^@vanilla-root/;
 
         let trueFilePath = "";
 
-        if (url.match(cssHttpImportRegex)) {
+        if (url.match(scssRegex)) {
+            trueFilePath = url.replace(scssRegex, this.vanillaDirectory);
+            printVerbose(`Mapping request SCSS import ${chalk.yellow(url)} to ${trueFilePath}`);
+        } else if (url.match(cssHttpImportRegex)) {
             // Ensure the file name is wrapped in quotes or we'll break the native css @import
             trueFilePath = `'${url}'`;
         } else if (url.match(nodeModuleRegex)) {
@@ -44,7 +48,7 @@ export default class SassTool {
         }
 
         return done({ file: trueFilePath });
-    }
+    };
 
     /**
      * Swap any placeholders comments in an SCSS file imports.

--- a/src/build/library/StylesheetBuilder.ts
+++ b/src/build/library/StylesheetBuilder.ts
@@ -21,7 +21,7 @@ export default class StylesheetBuilder {
     private sassTool: SassTool;
     constructor(private cliOptions: ICliOptions) {
         const { rootDirectories } = this.cliOptions;
-        this.sassTool = new SassTool(rootDirectories);
+        this.sassTool = new SassTool(rootDirectories, cliOptions.vanillaDirectory);
     }
 
     public compiler = () => {


### PR DESCRIPTION
This PR updates our SCSS path resolving to allow it to resolve files relative the dashboard application.

This is for immediate use in the theme boilerplate and we will likely extend to include our full set of aliases in the future, but for now the only significant place to bring things from is `@dashboard`.

**Usage**
```scss
@import "@dashboard/core-variables";
```