### PR TITLE
Fix natives on macos mojave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vanilla-cli",
-    "version": "2.7.1",
+    "version": "2.7.2",
     "private": true,
     "description": "Node.js tooling for the Vanilla Cli.",
     "repository": "https://github.com/vanilla/vanilla-cli",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "hard-source-webpack-plugin": "0.12.0",
         "html-loader": "0.5.5",
         "imagemin-pngquant": "6.0.0",
+        "natives": "1.1.6",
         "node-sass": "4.9.3",
         "postcss": "7.0.2",
         "postcss-sass": "0.3.2",
@@ -69,6 +70,9 @@
         "@types/webpack-merge": "4.1.3",
         "@types/yargs": "11.1.1",
         "@vanillaforums/prettier-config": "1.0.0"
+    },
+    "resolutions": {
+        "natives": "1.1.6"
     },
     "browserslist": [
         "ie > 9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5748,9 +5748,10 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-natives@^1.1.0:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.3.tgz#44a579be64507ea2d6ed1ca04a9415915cf75558"
+natives@1.1.6, natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
The old natives version was causing gulp to crash on startup with errors like:

```
/git/vanilla-cli/node_modules/natives/index.js:137
    fn(nm.exports, cachingRequire, nm, nm.filename)
    ^
ReferenceError: internalBinding is not defined
    at internal/util/inspect.js:31:15
    at req_ (/git/vanilla-cli/node_modules/natives/index.js:137:5)
    at require (/git/vanilla-cli/node_modules/natives/index.js:110:12)
    at util.js:25:21
    at req_ (/git/vanilla-cli/node_modules/natives/index.js:137:5)
    at require (/git/vanilla-cli/node_modules/natives/index.js:110:12)
    at fs.js:42:21
    at req_ (/git/vanilla-cli/node_modules/natives/index.js:137:5)
    at Object.req [as require] (/git/vanilla-cli/node_modules/natives/index.js:54:10)
    at Object.<anonymous> (/git/vanilla-cli/node_modules/gulp/node_modules/graceful-fs/fs.js:1:37)
```

Reference https://stackoverflow.com/questions/53146394/node-app-fails-to-run-on-mojave-referenceerror-internalbinding-is-not-defined

