### PR TITLE
Fix typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "ts-loader": "4.4.2",
         "ts-node": "6.0.5",
         "tslint": "5.11.0",
-        "typescript": "3.0.1",
+        "typescript": "3.5.3",
         "uglifyjs-webpack-plugin": "1.3.0",
         "webpack": "4.16.5",
         "webpack-hot-middleware": "2.22.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8380,9 +8380,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
+typescript@3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-es@^3.3.4:
   version "3.3.9"


### PR DESCRIPTION
The old version here was conflicting with the one in core preventing keystone/boilerplate from building.

Updating it fixes that.